### PR TITLE
fix: preserve worktree folders in sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-11-09
+
+### Fixed
+- Sidebar file tree now deduplicates markdown files reported by VS Code multi-root workspaces
+- Worktree and multi-root folder names are preserved when displaying files in the sidebar
+
+### Changed
+- Bumped extension version to `1.1.0`
+
 ## [0.9.8] - 2025-11-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "commentary",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "commentary",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.67.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "commentary",
   "displayName": "Commentary",
   "description": "Inline comments for rendered Markdown in VS Code. Select, annotate, review, and send to your AI agent, without touching the source file.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "publisher": "jaredhughes",
   "license": "MIT",
   "icon": "images/icon.png",


### PR DESCRIPTION
## Summary
- ensure the sidebar deduplicates markdown URIs returned by multi-root workspaces
- include workspace folder names when computing relative paths so git worktrees render correctly
- update changelog and bump extension to 1.1.0

## Testing
- npm run lint
- npm run compile
- npx vsce package

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Deduplicates markdown files from multi-root workspaces and includes workspace folder names in sidebar paths; bumps version to 1.1.0.
> 
> - **Sidebar**:
>   - Deduplicate markdown files returned by multi-root workspaces in `src/sidebar/commentsView.ts` when building the tree.
>   - Build tree using unique URIs; log deduplication counts.
> - **Utils**:
>   - Update `getWorkspaceRelativePath()` in `src/utils/fileTree.ts` to include workspace folder names when multiple roots, using `asRelativePath(uri, true)` and manual fallback.
>   - Ensures display paths/worktrees show folder context via `getDisplayPath()`.
> - **Release**:
>   - Update `CHANGELOG.md` with 1.1.0 fixes.
>   - Bump version to `1.1.0` in `package.json` and lockfile.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11a7797bfacd8fd59d9f28ff3720729a770827ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Resolved duplicate Markdown files appearing in multi-root VS Code workspaces
* Improved folder name display and preservation in the sidebar for multi-root workspace configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->