### PR TITLE
[#29] ci: publish-on-tag workflow for Marketplace + Open VSX

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,156 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish (e.g. v1.4.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      tag: ${{ steps.meta.outputs.tag }}
+      vsix: ${{ steps.meta.outputs.vsix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Resolve tag/version and verify match
+        id: meta
+        run: |
+          set -euo pipefail
+          tag="${{ inputs.tag || github.ref_name }}"
+          tag_version="${tag#v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "Tag version ($tag_version) does not match package.json version ($pkg_version)" >&2
+            exit 1
+          fi
+          vsix="commentary-${pkg_version}.vsix"
+          {
+            echo "version=$pkg_version"
+            echo "tag=$tag"
+            echo "vsix=$vsix"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate
+        run: npm run validate
+
+      - name: Package extension
+        run: |
+          mkdir -p vsix
+          npx --yes @vscode/vsce package --no-git-tag-version --out "vsix/${{ steps.meta.outputs.vsix }}"
+
+      - name: Upload VSIX artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: commentary-vsix
+          path: vsix/${{ steps.meta.outputs.vsix }}
+          retention-days: 30
+          if-no-files-found: error
+
+  publish-vscode-marketplace:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX
+        uses: actions/download-artifact@v4
+        with:
+          name: commentary-vsix
+          path: vsix
+
+      - name: Publish to VS Code Marketplace
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --yes @vscode/vsce publish --packagePath "vsix/${{ needs.build.outputs.vsix }}"
+
+  publish-open-vsx:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download VSIX
+        uses: actions/download-artifact@v4
+        with:
+          name: commentary-vsix
+          path: vsix
+
+      - name: Publish to Open VSX (with retry)
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        run: |
+          set -e
+          attempt=1
+          max_attempts=5
+          until npx --yes ovsx publish "vsix/${{ needs.build.outputs.vsix }}"; do
+            if [ $attempt -ge $max_attempts ]; then
+              echo "Open VSX publish failed after $attempt attempts" >&2
+              exit 1
+            fi
+            sleep $((attempt * 60))
+            attempt=$((attempt + 1))
+          done
+
+  create-github-release:
+    needs: [build, publish-vscode-marketplace]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.build.outputs.tag }}
+
+      - name: Download VSIX
+        uses: actions/download-artifact@v4
+        with:
+          name: commentary-vsix
+          path: vsix
+
+      - name: Extract changelog notes
+        run: |
+          set -euo pipefail
+          version="${{ needs.build.outputs.version }}"
+          awk -v v="$version" '
+            $0 ~ "^## \\[" v "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "No changelog section found for $version" >&2
+            exit 1
+          fi
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          tag="${{ needs.build.outputs.tag }}"
+          vsix="vsix/${{ needs.build.outputs.vsix }}"
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" "$vsix" --clobber
+            gh release edit "$tag" --notes-file release-notes.md
+          else
+            gh release create "$tag" "$vsix" --title "$tag" --notes-file release-notes.md
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,12 +11,12 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     outputs:
       version: ${{ steps.meta.outputs.version }}
       tag: ${{ steps.meta.outputs.tag }}
@@ -39,9 +39,16 @@ jobs:
 
       - name: Resolve tag/version and verify match
         id: meta
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
-          tag="${{ inputs.tag || github.ref_name }}"
+          tag="${INPUT_TAG:-$REF_NAME}"
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-].+)?$ ]]; then
+            echo "Tag '$tag' does not match expected vX.Y.Z format" >&2
+            exit 1
+          fi
           tag_version="${tag#v}"
           pkg_version="$(node -p "require('./package.json').version")"
           if [ "$tag_version" != "$pkg_version" ]; then
@@ -59,21 +66,29 @@ jobs:
         run: npm run validate
 
       - name: Package extension
+        # --no-git-tag-version: we're packaging an already-tagged commit; don't
+        # let vsce mutate package.json or create a tag.
+        env:
+          VSIX: ${{ steps.meta.outputs.vsix }}
         run: |
+          set -euo pipefail
           mkdir -p vsix
-          npx --yes @vscode/vsce package --no-git-tag-version --out "vsix/${{ steps.meta.outputs.vsix }}"
+          npx --yes '@vscode/vsce@^3' package --no-git-tag-version --out "vsix/$VSIX"
 
       - name: Upload VSIX artifact
         uses: actions/upload-artifact@v4
         with:
           name: commentary-vsix
           path: vsix/${{ steps.meta.outputs.vsix }}
-          retention-days: 30
+          retention-days: 7
           if-no-files-found: error
 
   publish-vscode-marketplace:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
       - name: Download VSIX
         uses: actions/download-artifact@v4
@@ -84,11 +99,25 @@ jobs:
       - name: Publish to VS Code Marketplace
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-        run: npx --yes @vscode/vsce publish --packagePath "vsix/${{ needs.build.outputs.vsix }}"
+          VSIX: ${{ needs.build.outputs.vsix }}
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          set -euo pipefail
+          # Idempotency: if this version is already on the Marketplace (e.g. a
+          # re-run via workflow_dispatch), skip rather than fail the job.
+          published="$(npx --yes '@vscode/vsce@^3' show jaredhughes.commentary --json 2>/dev/null | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{process.stdout.write(JSON.parse(s).versions[0].version)}catch{process.stdout.write("")}})' || true)"
+          if [ "$published" = "$VERSION" ]; then
+            echo "Marketplace already shows version $VERSION — skipping publish."
+            exit 0
+          fi
+          npx --yes '@vscode/vsce@^3' publish --packagePath "vsix/$VSIX"
 
   publish-open-vsx:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
     steps:
       - name: Download VSIX
         uses: actions/download-artifact@v4
@@ -99,22 +128,31 @@ jobs:
       - name: Publish to Open VSX (with retry)
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          VSIX: ${{ needs.build.outputs.vsix }}
         run: |
-          set -e
+          set -euo pipefail
           attempt=1
           max_attempts=5
-          until npx --yes ovsx publish "vsix/${{ needs.build.outputs.vsix }}"; do
-            if [ $attempt -ge $max_attempts ]; then
+          while true; do
+            if npx --yes 'ovsx@^0.10' publish "vsix/$VSIX"; then
+              break
+            fi
+            if [ "$attempt" -ge "$max_attempts" ]; then
               echo "Open VSX publish failed after $attempt attempts" >&2
               exit 1
             fi
-            sleep $((attempt * 60))
+            backoff=$((attempt * 60))
+            echo "Attempt $attempt failed, retrying in ${backoff}s..." >&2
+            sleep "$backoff"
             attempt=$((attempt + 1))
           done
 
   create-github-release:
     needs: [build, publish-vscode-marketplace]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -128,29 +166,30 @@ jobs:
           path: vsix
 
       - name: Extract changelog notes
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
         run: |
           set -euo pipefail
-          version="${{ needs.build.outputs.version }}"
-          awk -v v="$version" '
-            $0 ~ "^## \\[" v "\\]" { found=1; next }
-            found && /^## \[/ { exit }
+          awk -v v="$VERSION" '
+            index($0, "## [" v "]") == 1 { found=1; next }
+            found && index($0, "## [") == 1 { exit }
             found { print }
           ' CHANGELOG.md > release-notes.md
           if [ ! -s release-notes.md ]; then
-            echo "No changelog section found for $version" >&2
+            echo "No changelog section found for $VERSION" >&2
             exit 1
           fi
 
       - name: Create or update GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.build.outputs.tag }}
+          VSIX: ${{ needs.build.outputs.vsix }}
         run: |
           set -euo pipefail
-          tag="${{ needs.build.outputs.tag }}"
-          vsix="vsix/${{ needs.build.outputs.vsix }}"
-          if gh release view "$tag" >/dev/null 2>&1; then
-            gh release upload "$tag" "$vsix" --clobber
-            gh release edit "$tag" --notes-file release-notes.md
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" "vsix/$VSIX" --clobber
+            gh release edit "$TAG" --notes-file release-notes.md
           else
-            gh release create "$tag" "$vsix" --title "$tag" --notes-file release-notes.md
+            gh release create "$TAG" "vsix/$VSIX" --title "$TAG" --notes-file release-notes.md
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ media/demo/*.webm
 *.tmp.md
 *_draft.md
 *_temp.md
+.claude-cache/


### PR DESCRIPTION
## Summary
- New `.github/workflows/publish.yml` triggers on `v*` tag push (and `workflow_dispatch` for retries). Builds the `.vsix` once, then publishes to the VS Code Marketplace and Open VSX in parallel, and creates/updates the GitHub release with the `.vsix` attached and notes pulled from CHANGELOG.md.
- Removes the manual `vsce publish` / `ovsx publish` step from future releases. v1.4.1 was the last release published by hand.
- Open VSX step retries up to 5x with linear backoff to ride out the transient 503/Varnish errors we hit publishing 1.4.1.

## Required repo secrets
- `OVSX_PAT` — already set (from `op://Rustpoint/Open-vsx/...`, doesn't expire).
- `VSCE_PAT` — **needs to be set before the next release**. Run locally: `gh secret set VSCE_PAT --repo jaredhughes/commentary` and paste the PAT. When Microsoft expires it, repeat.

## Security / hardening (per review)
- All `${{ ... }}` expressions that flow into shell are hoisted into `env:` vars and referenced as `$VAR` (no expression-into-shell injection).
- `permissions:` scoped per-job: `contents: read` everywhere except `create-github-release` (`contents: write`).
- Marketplace publish is idempotent: skips cleanly if the listed version already matches (so `workflow_dispatch` re-runs after a half-failed publish don't blow up).
- Tag format validated (`vX.Y.Z[-prerelease]`) and verified to match `package.json` version before any publish.
- Tooling pinned by major (`@vscode/vsce@^3`, `ovsx@^0.10`); `timeout-minutes` on every job.

## Known follow-ups (not blockers)
- `vsce show` idempotency check compares against the latest-published version, so a deliberate downgrade re-run would still hit Marketplace and fail there (rare; clear error).
- `create-github-release` does not block on Open VSX — a failed Open VSX run leaves the GitHub release live without an Open VSX entry. Intentional: GH release shouldn't depend on a flaky third-party registry.

## Testing
- [ ] Land this PR.
- [ ] Set `VSCE_PAT` repo secret.
- [ ] Cut the next release (`v1.4.2` or `v1.5.0`) by tagging and pushing — workflow should publish to both registries and create the GitHub release without intervention.
- [ ] As a one-off, can use `workflow_dispatch` with `tag: v1.4.1` to retry Open VSX for 1.4.1 once the secret is set (Marketplace step will skip; GH release will refresh).

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated publishing workflow for release distribution to VS Code Marketplace and Open VSX Registry with version validation.
  * Updated build environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->